### PR TITLE
Documentation improvements

### DIFF
--- a/autocomplete.md
+++ b/autocomplete.md
@@ -137,3 +137,4 @@ Sometimes your work might require that all the search results be from a particul
 | `sources` | string | no | all sources: osm,oa,gn,wof | openstreetmap,wof |
 | `layers` | string | no | all layers: address,venue,neighbourhood,locality,borough,localadmin,county,macrocounty,region,macroregion,country,coarse | address,venue |
 | `boundary.country` | string | no | none | 'GBR' |
+| `boundary.gid` | Pelias `gid` | no | none | `whosonfirst:locality:101748355` |

--- a/place.md
+++ b/place.md
@@ -8,7 +8,7 @@ The `/place` endpoint accepts Pelias `gid` strings that get returned for every e
 
 For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap (OSM):
 
-> [/v1/place?api_key=your-mapzen-api-key&__ids=openstreetmap:venue:way:5013364__](https://pelias.github.io/compare/#/v1/place%3Fids=openstreetmap:venue:way:5013364)
+> [/v1/place?__ids=openstreetmap:venue:way:5013364__](https://pelias.github.io/compare/#/v1/place%3Fids=openstreetmap:venue:way:5013364)
 
 Note that you need an actual `gid` value to make a `/place` search. For example, if you search for an address and the result is [interpolated](addresses.md#address-interpolation), then there is no discrete `gid` to use for a `/place` search because interpolated results may be from multiple data sources.
 
@@ -16,7 +16,7 @@ Note that you need an actual `gid` value to make a `/place` search. For example,
 
 To search for more than one `/place` in a request, join multiple values together and separate them with a comma. For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap and the borough of Manhattan in Who's on First:
 
-> [/v1/place?api_key=your-mapzen-api-key&__ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771__](https://pelias.github.io/compare/#/v1/place%3Fids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771)
+> [/v1/place?__ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771__](https://pelias.github.io/compare/#/v1/place%3Fids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771)
 
 The results are returned in the order requested.
 

--- a/place.md
+++ b/place.md
@@ -8,7 +8,7 @@ The `/place` endpoint accepts Pelias `gid` strings that get returned for every e
 
 For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap (OSM):
 
-> [/v1/place?api_key=your-mapzen-api-key&__ids=openstreetmap:venue:way:5013364__](https://mapzen.com/search/explorer/?query=place&ids=openstreetmap:venue:way:5013364)
+> [/v1/place?api_key=your-mapzen-api-key&__ids=openstreetmap:venue:way:5013364__](https://pelias.github.io/compare/#/v1/place%3Fids=openstreetmap:venue:way:5013364)
 
 Note that you need an actual `gid` value to make a `/place` search. For example, if you search for an address and the result is [interpolated](addresses.md#address-interpolation), then there is no discrete `gid` to use for a `/place` search because interpolated results may be from multiple data sources.
 
@@ -16,7 +16,7 @@ Note that you need an actual `gid` value to make a `/place` search. For example,
 
 To search for more than one `/place` in a request, join multiple values together and separate them with a comma. For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap and the borough of Manhattan in Who's on First:
 
-> [/v1/place?api_key=your-mapzen-api-key&__ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771__](https://mapzen.com/search/explorer/?query=place&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771)
+> [/v1/place?api_key=your-mapzen-api-key&__ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771__](https://pelias.github.io/compare/#/v1/place%3Fids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771)
 
 The results are returned in the order requested.
 

--- a/response.md
+++ b/response.md
@@ -113,8 +113,8 @@ By default, Pelias results 10 places, unless otherwise specified. If you want a 
 | `text` | YMCA |
 | `size` | 1 |
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___size=1___](https://mapzen.com/search/explorer/?query=search&text=YMCA&size=1)
+> [/v1/search?__size=1__](https://pelias.github.io/compare/#/v1/search%3Ftext=YMCA&size=1)
 
 If you want 25 results, you can build the query where `size` is 25.
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___size=25___](https://mapzen.com/search/explorer/?query=search&text=YMCA&size=25)
+> [/v1/search?__size=25__](https://pelias.github.io/compare/#/v1/search%3Ftext=YMCA&size=25)

--- a/reverse.md
+++ b/reverse.md
@@ -103,16 +103,16 @@ Distance from `point.lat`/`point.lon` | Confidence score
 This section shows how the various parameters can be combined to form complex use cases.
 
 * All results near the Tower of London
->[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493](https://mapzen.com/search/explorer/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493)
+>[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493)
 
 * Only OpenStreetMap results near the Tower of London
->[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&sources=osm](https://mapzen.com/search/explorer/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&sources=osm)
+>[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&sources=osm](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&sources=osm)
 
 * Only street addresses near the Tower of London
->[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address](https://mapzen.com/search/explorer/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&layers=address)
+>[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&layers=address)
 
 * Only OpenStreetMap street addresses near the Tower of London
->[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm](https://mapzen.com/search/explorer/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm)
+>[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm)
 
 * Only the first OpenStreetMap address near the Tower of London
->[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1](https://mapzen.com/search/explorer/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1)
+>[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1)

--- a/reverse.md
+++ b/reverse.md
@@ -31,6 +31,7 @@ Parameter | Type | Required | Default | Example
 `layers` | comma-delimited string array | no | none (all layers) | `address,locality`
 `sources` | comma-delimited string array | no | none (all sources) | `oa,gn`
 `boundary.country` | <a href="https://en.wikipedia.org/wiki/ISO_3166-1" target="\_blank">ISO-3166 alpha-2 or alpha-3</a> | no | none | `FR`
+`boundary.gid` | Pelias `gid` | no | none | `whosonfirst:locality:101748355`
 
 ### Size
 

--- a/reverse.md
+++ b/reverse.md
@@ -102,17 +102,17 @@ Distance from `point.lat`/`point.lon` | Confidence score
 
 This section shows how the various parameters can be combined to form complex use cases.
 
-* All results near the Tower of London
->[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493)
+### All results near the Tower of London
+[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493)
 
-* Only OpenStreetMap results near the Tower of London
->[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&sources=osm](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&sources=osm)
+### Only OpenStreetMap results near the Tower of London
+[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&sources=osm](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&sources=osm)
 
-* Only street addresses near the Tower of London
->[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&layers=address)
+### Only street addresses near the Tower of London
+[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&layers=address)
 
-* Only OpenStreetMap street addresses near the Tower of London
->[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm)
+### Only OpenStreetMap street addresses near the Tower of London
+[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm)
 
-* Only the first OpenStreetMap address near the Tower of London
->[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1)
+### Only the first OpenStreetMap address near the Tower of London
+[/v1/reverse?point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1](https://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1)

--- a/search-workflows.md
+++ b/search-workflows.md
@@ -46,7 +46,7 @@ For coarse reverse, use the `/reverse` endpoint and `layers=coarse` or include a
 
 When you have live users who type things into input fields or search boxes, their activity falls into two scenarios, depending on when your app assumes they are ready to search.
 
-The distinction in the results is visible when you consider the behavior with the text of `lond`. Autocomplete for `lond`, returns `london` (https://mapzen.com/search/explorer/?query=autocomplete&text=lond) because the user is still typing, but `/search` assumes the user is done entering text and returns the city of `Lond` in Pakistan (https://mapzen.com/search/explorer/?query=search&text=lond).
+The distinction in the results is visible when you consider the behavior with the text of `lond`. Autocomplete for `lond`, returns `london` (https://pelias.github.io/compare/#/v1/autocomplete%3Ftext=lond) because the user is still typing, but `/search` assumes the user is done entering text and returns the city of `Lond` in Pakistan (https://pelias.github.io/compare/#/v1/search%3Ftext=lond).
 
 ### ...and want to show feedback as they type (`/autocomplete`)
 

--- a/search-workflows.md
+++ b/search-workflows.md
@@ -46,7 +46,7 @@ For coarse reverse, use the `/reverse` endpoint and `layers=coarse` or include a
 
 When you have live users who type things into input fields or search boxes, their activity falls into two scenarios, depending on when your app assumes they are ready to search.
 
-The distinction in the results is visible when you consider the behavior with the text of `lond`. Autocomplete for `lond`, returns `london` (https://pelias.github.io/compare/#/v1/autocomplete%3Ftext=lond) because the user is still typing, but `/search` assumes the user is done entering text and returns the city of `Lond` in Pakistan (https://pelias.github.io/compare/#/v1/search%3Ftext=lond).
+The distinction in the results is visible when you consider the behavior with the text of `lond`. [Autocomplete for `lond`, returns `london`](https://pelias.github.io/compare/#/v1/autocomplete%3Ftext=lond) because the user is still typing, but `/search` assumes the user is done entering text and [returns the city of `Lond` in Pakistan](https://pelias.github.io/compare/#/v1/search%3Ftext=lond).
 
 ### ...and want to show feedback as they type (`/autocomplete`)
 

--- a/search.md
+++ b/search.md
@@ -203,9 +203,9 @@ Many use cases call for the ability to promote nearby results to the top of the 
 
 ![Searching around a point](/images/focus_point.png)
 
-By specifying a `focus.point`, nearby places will be scored higher depending on how close they are to the `focus.point` so that places with higher scores will appear higher in the results list. The effect of this scoring boost diminishes to zero after 100 kilometers away from the `focus.point`. After all the nearby results have been found, additional results will come from the rest of the world, without any further location-based prioritization.
+By specifying a `focus.point`, results will be sorted in part by their proximity to the given coordinate. All else being equal, results closes to the point will show up higher. However, unlike a `boundary.circle` query, important results far from the given coordinate may still be returned. This allows, for example, [a query for places called Paris with a `focus.point` value in Texas to return both Paris, TX and Paris, France](http://pelias.github.io/compare/#/v1/autocomplete%3Ffocus.point.lat=33.7568&focus.point.lon=-95.5362&layers=locality&sources=wof&text=paris).
 
-To find YMCA again, but this time near a specific coordinate location (representing the Sydney Opera House) in Sydney, Australia, use `focus.point`.
+To find YMCAs again, but this time near a specific coordinate location (representing the Sydney Opera House) in Sydney, Australia, use `focus.point`.
 
 > [/v1/search?text=YMCA&__focus.point.lat=-33.856680&focus.point.lon=151.215281__](https://pelias.github.io/compare/#/v1/search%3Ffocus.point.lat=-33.856680&focus.point.lon=151.215281&text=ymca)
 

--- a/search.md
+++ b/search.md
@@ -78,11 +78,11 @@ By default, Pelias results up to 10 places, unless otherwise specified. If you w
 | `text` | YMCA |
 | `size` | 1 |
 
-> [/v1/search?text=YMCA&__size=1__](https://mapzen.com/search/explorer/?query=search&text=YMCA&size=1)
+> [/v1/search?text=YMCA&__size=1__](https://pelias.github.io/compare/#/v1/search%3Fsize=1&text=ymca)
 
 If you want 25 results, you can build the query where `size` is 25.
 
-> [/v1/search?text=YMCA&__size=25__](https://mapzen.com/search/explorer/?query=search&text=YMCA&size=25)
+> [/v1/search?text=YMCA&__size=25__](https://pelias.github.io/compare/#/v1/search%3Fsize=25&text=ymca)
 
 ## Narrow your search
 
@@ -96,7 +96,7 @@ Sometimes your work might require that all the search results be from a particul
 
 Now, you want to search for YMCA again, but this time only in Great Britain. To do this, you will need to know that the alpha-3 code for Great Britain is GBR and set the parameters like this:
 
-> [/v1/search?text=YMCA&__boundary.country=GBR__](https://mapzen.com/search/explorer/?query=search&text=YMCA&boundary.country=GBR)
+> [/v1/search?text=YMCA&__boundary.country=GBR__](https://pelias.github.io/compare/#/v1/search%3Fboundary.country=GBR&text=ymca)
 
 | parameter | value |
 | :--- | :--- |
@@ -118,7 +118,7 @@ Note that all the results are within Great Britain:
 
 If you try the same search request with different country codes, the results change to show YMCA locations within this region.
 
-> [/v1/search?text=YMCA&__boundary.country=USA__](https://mapzen.com/search/explorer/?query=search&text=YMCA&boundary.country=USA)
+> [/v1/search?text=YMCA&__boundary.country=USA__](https://pelias.github.io/compare/#/v1/search%3Fboundary.country=USA&text=ymca)
 
 Results in the United States:
 
@@ -143,7 +143,7 @@ For example, to find a YMCA within the state of Texas, you can set the `boundary
 
 Tip: You can look up a bounding box for a known region with this [web tool](http://boundingbox.klokantech.com/).
 
-> [/v1/search?text=YMCA&__boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51__](https://mapzen.com/search/explorer/?query=search&text=YMCA&boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51)
+> [/v1/search?text=YMCA&__boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51__](https://pelias.github.io/compare/#/v1/search%3Fboundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51&text=ymca)
 
 | parameter | value |
 | :--- | :--- |
@@ -172,7 +172,7 @@ Sometimes you don't have a rectangle to work with, but rather you have a point o
 
 In this example, you want to find all YMCA locations within a 35-kilometer radius of a location in Ontario, Canada. This time, you can use the `boundary.circle.*` parameter group, where `boundary.circle.lat` and `boundary.circle.lon` is your location in Ontario and `boundary.circle.radius` is the acceptable distance from that location. Note that the `boundary.circle.radius` parameter is always specified in kilometers.
 
-> [/v1/search?text=YMCA&__boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35__](https://mapzen.com/search/explorer/?query=search&text=YMCA&boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35)
+> [/v1/search?text=YMCA&__boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35__](https://pelias.github.io/compare/#/v1/search%3Fboundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35&text=ycma)
 
 | parameter | value |
 | :--- | :--- |
@@ -207,7 +207,7 @@ By specifying a `focus.point`, nearby places will be scored higher depending on 
 
 To find YMCA again, but this time near a specific coordinate location (representing the Sydney Opera House) in Sydney, Australia, use `focus.point`.
 
-> [/v1/search?text=YMCA&__focus.point.lat=-33.856680&focus.point.lon=151.215281__](https://mapzen.com/search/explorer/?query=search&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281)
+> [/v1/search?text=YMCA&__focus.point.lat=-33.856680&focus.point.lon=151.215281__](https://pelias.github.io/compare/#/v1/search%3Ffocus.point.lat=-33.856680&focus.point.lon=151.215281&text=ymca)
 
 | parameter | value |
 | :--- | :--- |
@@ -236,7 +236,7 @@ Now that you have seen how to use boundary and focus to narrow and sort your res
 
 Going back to the YMCA search you conducted with a focus around a point in Sydney, the results came back from distant parts of the world, as expected. But say you wanted to only see results from the country in which your focus point lies. You can combine that same focus point in Sydney with the country boundary of Australia like this.
 
-> [/v1/search?text=YMCA&__focus.point.lat=-33.856680&focus.point.lon=151.215281__](https://mapzen.com/search/explorer/?query=search&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281)
+> [/v1/search?text=YMCA&__focus.point.lat=-33.856680&focus.point.lon=151.215281__](https://pelias.github.io/compare/#/v1/search%3Ffocus.point.lat=-33.856680&focus.point.lon=151.215281&text=ymca)
 
 | parameter | value |
 | :--- | :--- |
@@ -262,7 +262,7 @@ The results below look different from the ones you saw before with only a focus 
 
 If you are looking for the nearest YMCA locations, and are willing to travel no farther than 50 kilometers from your current location, you likely would want the results to be sorted by distance from current location to make your selection process easier. You can get this behavior by using `focus.point` in combination with `boundary.circle.*`. You can use the `focus.point.*` values as the `boundary.circle.lat` and `boundary.circle.lon`, and add the required `boundary.circle.radius` value in kilometers.
 
-> [/v1/search?text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&__boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50__](https://mapzen.com/search/explorer/?query=search&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50)
+> [/v1/search?text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&__boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50__](https://pelias.github.io/compare/#/v1/search%3Ffocus.point.lat=-33.856680&focus.point.lon=151.215281&boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50&text=ymca)
 
 | parameter | value |
 | :--- | :--- |
@@ -303,7 +303,7 @@ The search examples so far have returned a mix of results from all the data sour
 
 If you use the `sources` parameter, you can choose which of these data sources to include in your search. So if you're only interested in finding a YMCA in data from OpenAddresses, for example, you can build a query specifying that data source.
 
-> [/v1/search?text=YMCA&__sources=oa__](https://mapzen.com/search/explorer/?query=search&text=YMCA&sources=oa)
+> [/v1/search?text=YMCA&__sources=oa__](https://pelias.github.io/compare/#/v1/search%3Fsources=oa&text=ymca)
 
 | parameter | value |
 | :--- | :--- |
@@ -325,7 +325,7 @@ Because OpenAddresses is, as the name suggests, only address data, here's what y
 
 If you wanted to combine several data sources together, set `sources` to a comma separated list of desired source names. Note that the order of the comma separated values does not impact sorting order of the results; they are still sorted based on the linguistic match quality to `text` and distance from `focus`, if you specified one.
 
-> [/v1/search?text=YMCA&__sources=osm,gn__](https://mapzen.com/search/explorer/?query=search&text=YMCA&sources=oa)
+> [/v1/search?text=YMCA&__sources=osm,gn__](https://pelias.github.io/compare/#/v1/search%3Fsources=osm,gn&text=ymca)
 
 | parameter | value |
 | :--- | :--- |
@@ -353,7 +353,7 @@ In Pelias, place types are referred to as `layers`, ranging from fine to coarse.
 |`country`|places that issue passports, nations, nation-states|
 |`coarse`|alias for simultaneously using all administrative layers (everything except `venue` and `address`)|
 
-> [/v1/search?text=YMCA&__layers=venue,address__](https://mapzen.com/search/explorer/?query=search&text=YMCA&layers=venue,address)
+> [/v1/search?text=YMCA&__layers=venue,address__](https://pelias.github.io/compare/#/v1/search%3Flayers=venue,address&text=ymca)
 
 | parameter | value |
 | :--- | :--- |

--- a/search.md
+++ b/search.md
@@ -190,6 +190,29 @@ You can see the results have fewer than the standard 10 items because there are 
 * Pinnacle Jr YMCA, Toronto, Ontario
 * Cooper Koo Family Cherry Street YMCA Centre, Toronto, Ontario
 
+### Search within a parent administrative area
+
+Pelias has a powerful understanding of relationships between places. In particular, it has a concept called the administrative hierarchy: each record in Pelias is listed as belonging to a parent neighbourhood, city, region, country, and other regions. This has many uses, including filtering. The Pelias global id (`gid`) of any record can be used with the `boundary.gid` filter to return only records with a given parent.
+
+For example, finding YMCAs in [Oklahoma](https://en.wikipedia.org/wiki/Oklahoma) with only a bounding box would be challenging: the bounding box would include much of nearby Texas, possibly leading to incorrect results.
+
+With `boundary.gid`, this query can return accurate results.
+
+> [/v1/search?text=YMCA&__boundary.gid=whosonfirst:region:85688585__](http://pelias.github.io/compare/#/v1/search%3Fboundary.gid=whosonfirst:region:85688585&text=ymca)
+
+* YMCA, Stillwater, OK, USA
+* YMCA, Edmond, OK, USA
+* YMCA, Guymon, OK, USA
+* YMCA, Grove, OK, USA
+* YMCA, Midwest City, OK, USA
+* YMCA, Shawnee, OK, USA
+* YMCA, Owasso, OK, USA
+* YMCA, Tulsa, OK, USA
+* YMCA, The Village, OK, USA
+* YMCA, Broken Arrow, OK, USA
+
+In the query above, `whosonfirst:region:85688585`, is the Pelias `gid` for Oklahoma, USA. Currently, all parent records come from the [Who's on First](https://whosonfirst.org/) project. `gid`s for records can be found using either the [Who's on First Spelunker](http://spelunker.whosonfirst.org/), a tool for searching Who's on First data, or from the responses of other Pelias queries. In this case a [search for Oklahoma](http://pelias.github.io/compare/#/v1/search%3Ftext=oklahoma) will return the proper `gid`.
+
 ### Specify multiple boundaries
 
 ![Searching within multiple regions](/images/overlapping_boundaries.gif)
@@ -374,6 +397,7 @@ In Pelias, place types are referred to as `layers`, ranging from fine to coarse.
 | `boundary.circle.lat` | floating point number | no | none | `43.818156` |
 | `boundary.circle.lon` | floating point number | no | none | `-79.186484` |
 | `boundary.circle.radius` | floating point number | no | 50 | `35` |
+| `boundary.gid` | Pelias `gid` | no | none | `whosonfirst:locality:101748355` |
 | `sources` | string | no | all sources: osm,oa,gn,wof | openstreetmap,wof |
 | `layers` | string | no | all layers: address,venue,neighbourhood,locality,borough,localadmin,county,macrocounty,region,macroregion,country,coarse | address,venue |
 | `boundary.country` | string | no | none | 'GBR' |

--- a/structured-geocoding.md
+++ b/structured-geocoding.md
@@ -48,9 +48,9 @@ The `address` parameter can contain a full address with house number or only a s
 
 _Examples_
 
-* [201 Spear Street](https://mapzen.com/search/explorer/?query=search/structured&address=201 Spear Street&locality=San Francisco&region=CA)
-* [Rue de Rivoli](https://mapzen.com/search/explorer/?query=search/structured&address=Rue de Rivoli&locality=Paris&region=France)
-* [Přílucká 1](https://mapzen.com/search/explorer/?query=search/structured&address=1 Přílucká&locality=Želechovice nad Dřevnicí)
+* [201 Spear Street](http://pelias.github.io/compare/#/v1/search/structured%3Faddress=201%20Spear%20Street&locality=San%20Francisco&region=CA)
+* [Rue de Rivoli](http://pelias.github.io/compare/#/v1/search/structured%3Faddress=Rue%20de%20Rivoli&locality=Paris&region=France)
+* [Přílucká 1](http://pelias.github.io/compare/#/v1/search/structured%3Faddress=1%20P%C5%99%C3%ADluck%C3%A1&locality=%C5%BDelechovice%20nad%20D%C5%99evnic%C3%AD)
 
 ### neighbourhood
 
@@ -58,9 +58,9 @@ _Examples_
 
 _Examples_
 
-* [Notting Hill](https://mapzen.com/search/explorer/?query=search/structured&neighbourhood=Notting Hill&locality=London) in London
-* [Flatiron District](https://mapzen.com/search/explorer/?query=search/structured&neighbourhood=Flatiron District&borough=Manhattan) in Manhattan
-* [Le Marais](https://mapzen.com/search/explorer/?query=search/structured&neighbourhood=Le Marais&locality=Paris) in Paris
+* [Notting Hill](https://pelias.github.io/compare/#/v1/search/structured%3Fneighbourhood=Notting%20Hill&locality=London) in London
+* [Flatiron District](https://pelias.github.io/compare/#/v1/search/structured%3Fneighbourhood=Flatiron%20District&borough=Manhattan) in Manhattan
+* [Le Marais](https://pelias.github.io/compare/#/v1/search/structured%3Fneighbourhood=Le%20Marais&locality=Paris) in Paris
 
 ### borough
 
@@ -68,8 +68,8 @@ _Examples_
 
 _Examples_
 
-* [Manhattan](https://mapzen.com/search/explorer/?query=search/structured&borough=Manhattan&locality=New York)
-* [Iztapalapa](https://mapzen.com/search/explorer/?query=search/structured&borough=Iztapalapa&locality=Mexico City)
+* [Manhattan](https://pelias.github.io/compare/#/v1/search/structured%3Fborough=Manhattan&locality=New%20York)
+* [Iztapalapa](https://pelias.github.io/compare/#/v1/search/structured%3Fborough=Iztapalapa&locality=Mexico%20City)
 
 A structured geocoding request for `/v1/search/structured?locality=Manhattan&region=NY`, returns boroughs along with localities.
 
@@ -79,9 +79,9 @@ A structured geocoding request for `/v1/search/structured?locality=Manhattan&reg
 
 _Examples_
 
-* [Bangkok](https://mapzen.com/search/explorer/?query=search/structured&locality=Bangkok&country=Thailand)
-* [Caracas](https://mapzen.com/search/explorer/?query=search/structured&locality=Caracas&country=Venezuela)
-* [Truth or Consequences](https://mapzen.com/search/explorer/?query=search/structured&locality=Truth or Consequences&region=NM) in New Mexico
+* [Bangkok](https://pelias.github.io/compare/#/v1/search/structured%3Flocality=Bangkok&country=Thailand)
+* [Caracas](https://pelias.github.io/compare/#/v1/search/structured%3Flocality=Caracas&country=Venezuela)
+* [Truth or Consequences](https://pelias.github.io/compare/#/v1/search/structured%3Flocality=Truth%20or%20Consequences&region=NM) in New Mexico
 
 ### county
 
@@ -89,9 +89,9 @@ _Examples_
 
 _Examples_
 
-* [Bucks](https://mapzen.com/search/explorer/?query=search/structured&county=Bucks&region=PA) in Pennsylvania
-* [Maui](https://mapzen.com/search/explorer/?query=search/structured&county=Maui&region=HI)
-* [Alb-Donau-Kreis](https://mapzen.com/search/explorer/?query=search/structured&county=Alb-Donau-Kreis&country=DEU) in Germany
+* [Bucks](https://pelias.github.io/compare/#/v1/search/structured%3Fcounty=Bucks&region=PA) in Pennsylvania
+* [Maui](https://pelias.github.io/compare/#/v1/search/structured%3Fcounty=Maui&region=HI)
+* [Alb-Donau-Kreis](https://pelias.github.io/compare/#/v1/search/structured%3Fcounty=Alb-Donau-Kreis&country=DEU) in Germany
 
 Counties are not as commonly used in geocoding as localities, but can be useful when attempting to disambiguate between localities. For instance, there are three cities named Red Lion in Pennsylvania but only one in each of three counties. Specifying a county disambiguates this list to a single result.
 
@@ -101,9 +101,9 @@ Counties are not as commonly used in geocoding as localities, but can be useful 
 
 _Examples_
 
-* [Delaware](https://mapzen.com/search/explorer/?query=search/structured&region=Delaware)
-* [Ontario](https://mapzen.com/search/explorer/?query=search/structured&region=Ontario)
-* [Ardennes](https://mapzen.com/search/explorer/?query=search/structured&region=Ardennes)
+* [Delaware](https://pelias.github.io/compare/#/v1/search/structured%3Fregion=Delaware)
+* [Ontario](https://pelias.github.io/compare/#/v1/search/structured%3Fregion=Ontario)
+* [Ardennes](https://pelias.github.io/compare/#/v1/search/structured%3Fregion=Ardennes)
 
 Regions in the United States have [common abbreviations](https://en.wikipedia.org/wiki/List_of_U.S._state_abbreviations), such as PA for [Pennsylvania](https://spelunker.whosonfirst.org/id/85688481/) and NM for [New Mexico](https://spelunker.whosonfirst.org/id/85688493/).  The `region` parameter can be a full name or abbreviation, so specifying `/v1/search/structured?region=NM` is functionality equivalent to `/v1/search/structured?region=New Mexico`.
 
@@ -117,7 +117,7 @@ _Examples_
 * [CV23 9SL](https://spelunker.whosonfirst.org/id/454261459/)
 * [5439171](https://spelunker.whosonfirst.org/id/538904173/)
 
-Keep in mind that you can search for `postalcode` exclusively. So requests like [/v1/search/structured?postalcode=87801]( https://mapzen.com/search/explorer/?query=search/structured&postalcode=87801) will return matching postalcode records.
+Keep in mind that you can search for `postalcode` exclusively. So requests like [/v1/search/structured?postalcode=87801]( https://pelias.github.io/compare/#/v1/search/structured?postalcode=87801) will return matching postalcode records.
 
 ### country
 
@@ -125,9 +125,9 @@ Keep in mind that you can search for `postalcode` exclusively. So requests like 
 
 _Examples_
 
-* [Liechtenstein](https://mapzen.com/search/explorer/?query=search/structured&country=Liechtenstein)
-* [CMR](https://mapzen.com/search/explorer/?query=search/structured&country=CMR) ([Cameroon](https://spelunker.whosonfirst.org/id/85632245/))
-* [Bermuda](https://mapzen.com/search/explorer/?query=search/structured&country=Bermuda)
+* [Liechtenstein](https://pelias.github.io/compare/#/v1/search/structured%3Fcountry=Liechtenstein)
+* [CMR](https://pelias.github.io/compare/#/v1/search/structured%3Fcountry=CMR) ([Cameroon](https://spelunker.whosonfirst.org/id/85632245/))
+* [Bermuda](https://pelias.github.io/compare/#/v1/search/structured%3Fcountry=Bermuda)
 
 ## Who's On First layer mappings reference
 


### PR DESCRIPTION
This started out as a small PR to improve links on the `structured` endpoint docs, but quickly outgrew that description.

Included are fixes to:
- Add documentation for the new [boundary.gid](https://github.com/pelias/api/pull/1249) parameter
- remove all links that used the Mapzen Search Explorer tool, which has gone away with the [Mapzen shutdown](https://github.com/pelias/pelias/issues/703). The well-maintained and independently hosted [Pelias Compare app](http://pelias.github.io/compare/) is used instead.
- Improve the documentation of `focus.point`. It had some out of date technical details and did not do a good job of describing the "soft" nature of the query parameter.
- Remove any remaining mentions of Mapzen API keys. These were a relic of the days with this was really documentation for Mapzen Search, not Pelias.
- Fix a few other typos, mistakes, etc