### PR TITLE
Use Elasticsearch 5 as the default version in docs

### DIFF
--- a/development/roadmap.md
+++ b/development/roadmap.md
@@ -28,14 +28,14 @@ autocomplete endpoint. Some features to implement:
 - Better multi-language search support
 - Improved handling of synonyms/abbreviations
 
-## Elasticsearch 5 Support
+## Elasticsearch 6 Support
 
-Pelias is currently only compatible and well tested on Elasticsearch 2. While
-the code changes required to support Elasticsearch 5 are minimal, testing and
-validating Elasticsearch 5 as the default version is not complete and will
-require significant work including testing full planet builds.
+Pelias is currently only compatible and well tested on Elasticsearch 2 and 5.
+Elasticsearch 6 does come with some breaking changes that will require
+development work, but comes with performance and feature improvements we'd like
+to take advantage of.
 
-https://github.com/pelias/pelias/issues/461
+https://github.com/pelias/pelias/issues/719
 
 ## Expanded input language support
 

--- a/pelias_from_scratch.md
+++ b/pelias_from_scratch.md
@@ -167,7 +167,7 @@ As you can see, the default datapaths are meant to be changed.
 
 ### Install Elasticsearch
 
-Please refer to the [official 2.4 install docs](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/setup.html) for how to install Elasticsearch.
+Please refer to the [official 5.6 install docs](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/setup.html) for how to install Elasticsearch.
 
 Be sure to modify the Elasticsearch [heap size](https://www.elastic.co/guide/en/elasticsearch/guide/2.x/heap-sizing.html) as appropriate to your machine.
 

--- a/requirements.md
+++ b/requirements.md
@@ -15,13 +15,13 @@ However we gladly accept patches and bug reports regarding issues with any Node.
 
 ## Elasticsearch
 
-Version 2.4 or 5.6
+Version 5.6
 
-The core data storage for Pelias is Elasticsearch. We recommend the latest in the 2.4 release line.
+The core data storage for Pelias is Elasticsearch. We recommend the latest in the 5.6 release line.
 
-Support for [Elasticsearch 5](https://github.com/pelias/pelias/issues/461) is new and should not yet be considered production-ready.
+Support for Elasticsearch 2.4 has been officially dropped, although it may continue to work for some time.
 
-[Elasticsearch 6](https://github.com/pelias/pelias/issues/719) support will follow once Elasticsearch 5 has been the recommended version for some time.
+[Elasticsearch 6](https://github.com/pelias/pelias/issues/719) support is currently in progress, which will require making breaking changes that will not allow Elasticsearch 2.4 suppport to continue.
 
 ## SQLite
 


### PR DESCRIPTION
This ensures all our documentation is consistent with support for ES5, and officially dropping support for ES2, as part of https://github.com/pelias/pelias/issues/461