### PR TITLE
Explain the Pelias release process

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,13 @@
 # Pelias Release Notes
 
-Pelias release notes are now published on a per-repository basis on GitHub.
+Pelias as a whole operates on a rolling-release process where we generally recommend the latest version of each individual component.
+
+In general, it's safe to mix and match newer and older versions of different components, or upgrade one component at a time.
+
+We try to avoid it, but when there is a breaking change in one component
+results in a, we publish a new _major version_ of that component.
+
+Each component has its own release nots published on GitHub.
 
 For example, you can view the release notes for the Pelias API at https://github.com/pelias/api/releases.
 


### PR DESCRIPTION
Pelias components (importers and services) are released individually, and we don't have a "complete" release. This isn't called out explicitly anywhere as far as I know, so we add it to the top of the release notes.

Closes https://github.com/pelias/documentation/issues/276