### PR TITLE
Using the right order of the layers and adding missing ones

### DIFF
--- a/autocomplete.md
+++ b/autocomplete.md
@@ -134,23 +134,28 @@ without `sources=openaddresses` you will find the most popular Pennsylvanias fir
 
 ### Layers
 
-The type of record is referred to as its `layer`. All records are indexed into the following layers:
+The type of record is referred to as its `layer`. All records are indexed into the following layers (sorted by granularity):
 
 |layer|description|
 |----|----|
 |`venue`|points of interest, businesses, things with walls|
 |`address`|places with a street address|
 |`street`|streets,roads,highways|
-|`country`|places that issue passports, nations, nation-states|
-|`macroregion`|a related group of regions. Mostly in Europe|
-|`region`|states and provinces|
-|`macrocounty`|a related group of counties. Mostly in Europe.|
-|`county`|official governmental area; usually bigger than a locality, almost always smaller than a region|
+|`neighbourhood`|social communities, neighbourhoods|
+|`borough`|a local administrative boundary|
 |`locality`|towns, hamlets, cities|
 |`localadmin`|local administrative boundaries|
-|`borough`| a local administrative boundary, currently only used for New York City|
-|`neighbourhood`|social communities, neighbourhoods|
-|`coarse`|alias for simultaneously using all administrative layers (everything except `venue` and `address`)|
+|`county`|official governmental area; usually bigger than a locality, almost always smaller than a region|
+|`macrocounty`|a related group of counties. Mostly in Europe.|
+|`region`|states and provinces|
+|`macroregion`|a related group of regions. Mostly in Europe|
+|`dependency`|places that issue passports, dependent on a parent country or member of an empire such as French Polynesia member of French empire|
+|`country`|places that issue passports, nations, nation-states|
+|`empire`|contains one country and many dependencies|
+|`continent`|eight continents on earth|
+|`marinearea`|water areas smaller than oceans|
+|`ocean`|seven oceans on earth|
+|`coarse`|alias for simultaneously using all administrative layers (everything except `venue`, `address` and `street`)|
 |`postalcode`|postal code used by mail services|
 
 > /v1/autocomplete?__layers=coarse__&text=starbuck

--- a/reverse.md
+++ b/reverse.md
@@ -62,21 +62,27 @@ Without specifying further, reverse geocoding doesn't restrict results to a part
 
 Here are all the supported layers and their meanings.
 
-|layer|description|
+||layer|description|
 |----|----|
 |`venue`|points of interest, businesses, things with walls|
 |`address`|places with a street address|
 |`street`|streets,roads,highways|
-|`country`|places that issue passports, nations, nation-states|
-|`macroregion`|a related group of regions. Mostly in Europe|
-|`region`|states and provinces|
-|`macrocounty`|a related group of counties. Mostly in Europe.|
-|`county`|official governmental area; usually bigger than a locality, almost always smaller than a region|
+|`neighbourhood`|social communities, neighbourhoods|
+|`borough`|a local administrative boundary|
 |`locality`|towns, hamlets, cities|
 |`localadmin`|local administrative boundaries|
-|`borough`| a local administrative boundary, currently only used for New York City|
-|`neighbourhood`|social communities, neighbourhoods|
-|`coarse`|alias for simultaneously using all administrative layers (everything except `venue` and `address`)|
+|`county`|official governmental area; usually bigger than a locality, almost always smaller than a region|
+|`macrocounty`|a related group of counties. Mostly in Europe.|
+|`region`|states and provinces|
+|`macroregion`|a related group of regions. Mostly in Europe|
+|`dependency`|places that issue passports, dependent on a parent country or member of an empire such as French Polynesia member of French empire|
+|`country`|places that issue passports, nations, nation-states|
+|`empire`|contains one country and many dependencies|
+|`continent`|eight continents on earth|
+|`marinearea`|water areas smaller than oceans|
+|`ocean`|seven oceans on earth|
+|`coarse`|alias for simultaneously using all administrative layers (everything except `venue`, `address` and `street`)|
+|`postalcode`|postal code used by mail services|
 
 ### Filter by country
 

--- a/search.md
+++ b/search.md
@@ -351,15 +351,20 @@ Here's a list of the types of places you could find in the results, sorted by gr
 |`address`|places with a street address|
 |`street`|streets,roads,highways|
 |`neighbourhood`|social communities, neighbourhoods|
-|`borough`|a local administrative boundary, currently only used for New York City|
-|`localadmin`|local administrative boundaries|
+|`borough`|a local administrative boundary|
 |`locality`|towns, hamlets, cities|
+|`localadmin`|local administrative boundaries|
 |`county`|official governmental area; usually bigger than a locality, almost always smaller than a region|
 |`macrocounty`|a related group of counties. Mostly in Europe.|
 |`region`|states and provinces|
 |`macroregion`|a related group of regions. Mostly in Europe|
+|`dependency`|places that issue passports, dependent on a parent country or member of an empire such as French Polynesia member of French empire|
 |`country`|places that issue passports, nations, nation-states|
-|`coarse`|alias for simultaneously using all administrative layers (everything except `venue` and `address`)|
+|`empire`|contains one country and many dependencies|
+|`continent`|eight continents on earth|
+|`marinearea`|water areas smaller than oceans|
+|`ocean`|seven oceans on earth|
+|`coarse`|alias for simultaneously using all administrative layers (everything except `venue`, `address` and `street`)|
 |`postalcode`|postal code used by mail services|
 
 > [/v1/search?text=YMCA&__layers=venue,address__](https://pelias.github.io/compare/#/v1/search%3Flayers=venue,address&text=ymca)


### PR DESCRIPTION
Hi there, I hope you are doing well :smile: 

I saw that some layers were missing in the documentation and locality and localadmin were reversed.

I also removed the example of New Yor City for `borough` because now it's used in 15 countries.